### PR TITLE
Add dashboard play modal and autoclose cleanup logic

### DIFF
--- a/client/server/admin/dashboard.html
+++ b/client/server/admin/dashboard.html
@@ -273,6 +273,32 @@
       font-weight: 600;
     }
 
+    .modal-card p {
+      margin: 0;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .modal-card .input-group {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .checkbox-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      color: var(--text-secondary);
+      font-size: 14px;
+    }
+
+    input[type="checkbox"] {
+      width: 18px;
+      height: 18px;
+      accent-color: var(--accent);
+    }
+
     .modal-actions {
       display: flex;
       gap: 12px;
@@ -290,6 +316,25 @@
       <div class="modal-actions">
         <button type="button" class="ghost" id="modalCancel">Cancel</button>
         <button type="button" class="primary" id="modalApply">Unlock</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal-backdrop" id="playModal">
+    <div class="modal-card">
+      <h2>Play Video</h2>
+      <p>Provide the video URL and configure whether the session should close automatically when it ends.</p>
+      <div class="input-group">
+        <label for="playUrl">Video URL</label>
+        <input type="text" id="playUrl" placeholder="https://example.com/video.mp4" />
+      </div>
+      <label class="checkbox-row">
+        <input type="checkbox" id="playAutoclose" />
+        <span>Autoclose when playback finishes</span>
+      </label>
+      <div class="modal-actions">
+        <button type="button" class="ghost" id="playCancel">Cancel</button>
+        <button type="button" class="primary" id="playConfirm">Play</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a play modal in the admin dashboard to collect the target video url and autoclose preference before starting playback
- wire the dashboard controls to launch the modal, send play-instant commands with session metadata, and provide prompt fallbacks
- close out autoclose sessions on the backend when clients report an ended state so they leave their play group automatically

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6a4d575883308de01a3ccee26534