### PR TITLE
Delay modal until activation, add preload and playlist

### DIFF
--- a/client/server/admin/dashboard.js
+++ b/client/server/admin/dashboard.js
@@ -305,8 +305,6 @@
       items.push(createSeekControl(token));
     }
 
-    items.push(createVolumeControl(token));
-
     return items;
   }
 
@@ -325,26 +323,6 @@
         return;
       }
       sendCommand('seek', token, { toMs: value });
-    });
-
-    container.appendChild(input);
-    container.appendChild(button);
-    return container;
-  }
-
-  function createVolumeControl(token) {
-    const container = document.createElement('div');
-
-    const input = document.createElement('input');
-    input.type = 'range';
-    input.min = '0';
-    input.max = '100';
-    input.value = '100';
-    input.style.width = '100px';
-
-    const button = createActionButton('Set Volume', () => {
-      const vol = Number(input.value) / 100;
-      sendCommand('set-volume', token, { volume: vol });
     });
 
     container.appendChild(input);


### PR DESCRIPTION
## Summary
- defer the video modal until the OpenAudio client is activated, add preload support, and manage queued playlists on the client
- expose `/admin/video/preload` and `/admin/video/initialize-playlist` endpoints while tracking preload/playlist metadata on the backend
- simplify the admin dashboard controls by removing the unused volume slider

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6ec7a8f08330b10357e2f9802f16