### PR TITLE
Add region media controls and admin UI

### DIFF
--- a/client/server/admin/dashboard.html
+++ b/client/server/admin/dashboard.html
@@ -163,6 +163,34 @@
       overflow: hidden;
     }
 
+    .tabs {
+      display: flex;
+      gap: 12px;
+    }
+
+    .tab-button {
+      background: transparent;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      color: var(--text-secondary);
+      padding: 10px 18px;
+      border-radius: 10px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    }
+
+    .tab-button.active {
+      background: rgba(79, 70, 229, 0.18);
+      border-color: rgba(79, 70, 229, 0.55);
+      color: var(--text-primary);
+      box-shadow: 0 6px 20px rgba(79, 70, 229, 0.25);
+    }
+
+    .tab-content.hidden {
+      display: none;
+    }
+
     table {
       width: 100%;
       border-collapse: collapse;
@@ -359,15 +387,22 @@
     <section class="status-bar">
       <div><strong>Connections:</strong> <span id="connCount">0</span></div>
       <div><strong>Active Sessions:</strong> <span id="activeCount">0</span></div>
+      <div><strong>Regions:</strong> <span id="regionCount">0</span></div>
       <div><strong>Last Refresh:</strong> <span id="lastRefresh">—</span></div>
     </section>
 
-    <section class="table-wrapper">
+    <nav class="tabs">
+      <button type="button" class="tab-button active" data-tab="connections">Connections</button>
+      <button type="button" class="tab-button" data-tab="regions">Regions</button>
+    </nav>
+
+    <section class="table-wrapper tab-content" id="connectionsSection">
       <table>
         <thead>
           <tr>
             <th>Token</th>
             <th>Player</th>
+            <th>Region</th>
             <th>Session</th>
             <th>Status</th>
             <th>Position</th>
@@ -379,7 +414,29 @@
         </thead>
         <tbody id="connectionsBody">
           <tr>
-            <td colspan="9" class="empty-state">Enter the admin key to load connections.</td>
+            <td colspan="10" class="empty-state">Enter the admin key to load connections.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="table-wrapper tab-content hidden" id="regionsSection">
+      <table>
+        <thead>
+          <tr>
+            <th>Region</th>
+            <th>Members</th>
+            <th>Status</th>
+            <th>Position</th>
+            <th>Volume</th>
+            <th>Autoclose</th>
+            <th>Updated</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody id="regionsBody">
+          <tr>
+            <td colspan="8" class="empty-state">Enter the admin key to load regions.</td>
           </tr>
         </tbody>
       </table>

--- a/client/server/index.test.js
+++ b/client/server/index.test.js
@@ -1,0 +1,168 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const serverModule = require('./index');
+
+const {
+  applyRegionForClient,
+  assignRegionForPlayerKey,
+  assignRegionForToken,
+  normalizeRegionId,
+  registerMediaCommand,
+} = serverModule;
+
+const {
+  clientsByToken,
+  activeMediaByRegion,
+  activeMediaByToken,
+  tokensByRegion,
+  resetInMemoryStores,
+} = serverModule._internals;
+
+test.beforeEach(() => {
+  resetInMemoryStores();
+});
+
+test('applyRegionForClient assigns preconfigured region and syncs playback', () => {
+  const originalNow = Date.now;
+  try {
+    const baseTime = 1_000_000;
+    Date.now = () => baseTime;
+
+    const regionId = normalizeRegionId('Spawn Plaza', { displayName: 'Spawn Plaza' });
+    assignRegionForPlayerKey('id:player-123', regionId);
+
+    registerMediaCommand(activeMediaByRegion, regionId, {
+      type: 'VIDEO_INIT',
+      url: 'https://cdn.example.com/intro.mp4',
+      startAtEpochMs: baseTime,
+      volume: 0.5,
+    });
+    registerMediaCommand(activeMediaByRegion, regionId, {
+      type: 'VIDEO_PLAY',
+      startAtEpochMs: baseTime,
+      atMs: 0,
+      volume: 0.5,
+    });
+
+    Date.now = () => baseTime + 3000;
+
+    const sentMessages = [];
+    const token = 'token-abc';
+    clientsByToken.set(token, {
+      ws: {
+        readyState: 1,
+        send(payload) {
+          sentMessages.push(JSON.parse(payload));
+        },
+      },
+      playerId: 'player-123',
+      playerUuid: null,
+      playerName: null,
+      region: null,
+      regionDisplayName: null,
+    });
+
+    const assignedRegion = applyRegionForClient(token, clientsByToken.get(token));
+
+    assert.equal(assignedRegion, regionId);
+    assert.equal(clientsByToken.get(token).region, regionId);
+    assert.equal(sentMessages.length, 2);
+    assert.equal(sentMessages[0].type, 'VIDEO_INIT');
+    assert.equal(sentMessages[0].resume, true);
+    assert.equal(sentMessages[0].url, 'https://cdn.example.com/intro.mp4');
+    assert.equal(sentMessages[1].type, 'VIDEO_PLAY');
+    assert.equal(sentMessages[1].atMs, 3000);
+    assert(sentMessages[1].autoclose === false || sentMessages[1].autoclose === undefined);
+
+    const perTokenRecord = activeMediaByToken.get(token);
+    assert(perTokenRecord, 'expected media record for token');
+    assert.equal(perTokenRecord.state.status, 'playing');
+    assert.equal(perTokenRecord.state.url, 'https://cdn.example.com/intro.mp4');
+
+    const members = tokensByRegion.get(regionId);
+    assert(members && members.has(token), 'token should be tracked in region membership');
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test('applyRegionForClient resumes playback for returning player', () => {
+  const originalNow = Date.now;
+  try {
+    const baseTime = 2_000_000;
+    Date.now = () => baseTime;
+
+    const regionId = normalizeRegionId('Lobby', { displayName: 'Lobby' });
+    assignRegionForPlayerKey('id:player-xyz', regionId);
+
+    registerMediaCommand(activeMediaByRegion, regionId, {
+      type: 'VIDEO_INIT',
+      url: 'https://cdn.example.com/welcome.mp4',
+      startAtEpochMs: baseTime,
+      volume: 0.8,
+    });
+    registerMediaCommand(activeMediaByRegion, regionId, {
+      type: 'VIDEO_PLAY',
+      startAtEpochMs: baseTime,
+      atMs: 0,
+      volume: 0.8,
+    });
+
+    Date.now = () => baseTime + 1200;
+    const firstMessages = [];
+    const firstToken = 'token-old';
+    clientsByToken.set(firstToken, {
+      ws: {
+        readyState: 1,
+        send(payload) {
+          firstMessages.push(JSON.parse(payload));
+        },
+      },
+      playerId: 'player-xyz',
+      playerUuid: null,
+      playerName: null,
+      region: null,
+      regionDisplayName: null,
+    });
+
+    const firstAssigned = applyRegionForClient(firstToken, clientsByToken.get(firstToken));
+    assert.equal(firstAssigned, regionId);
+    assert.equal(firstMessages[0].type, 'VIDEO_INIT');
+    assert.equal(firstMessages[1].type, 'VIDEO_PLAY');
+    assert.equal(firstMessages[1].atMs, 1200);
+
+    assignRegionForToken(firstToken, null, { alreadyCanonical: true });
+    clientsByToken.delete(firstToken);
+
+    Date.now = () => baseTime + 4800;
+
+    const secondMessages = [];
+    const reconnectToken = 'token-new';
+    clientsByToken.set(reconnectToken, {
+      ws: {
+        readyState: 1,
+        send(payload) {
+          secondMessages.push(JSON.parse(payload));
+        },
+      },
+      playerId: 'player-xyz',
+      playerUuid: null,
+      playerName: null,
+      region: null,
+      regionDisplayName: null,
+    });
+
+    const secondAssigned = applyRegionForClient(reconnectToken, clientsByToken.get(reconnectToken));
+    assert.equal(secondAssigned, regionId);
+    assert.equal(secondMessages[0].type, 'VIDEO_INIT');
+    assert.equal(secondMessages[1].type, 'VIDEO_PLAY');
+    assert.equal(secondMessages[1].atMs, 4800);
+
+    const members = tokensByRegion.get(regionId);
+    assert(members && members.has(reconnectToken), 'returning token should be tracked in region');
+    assert(!members || !members.has(firstToken), 'old token should not remain in region members');
+  } finally {
+    Date.now = originalNow;
+  }
+});

--- a/client/server/package.json
+++ b/client/server/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- add region membership tracking, region media state storage, and a /set-region API to sync playback across players entering a region
- expose region activity through a new /admin/video/regions endpoint and allow media commands to target regions alongside individual players
- update the admin dashboard with a Regions tab that lists current region playback, membership, and provides play/pause/stop controls

## Testing
- node -e "new Function(require('fs').readFileSync('client/server/index.js','utf8'))"
- node -e "new Function(require('fs').readFileSync('client/server/admin/dashboard.js','utf8'))"

------
https://chatgpt.com/codex/tasks/task_e_68cf786016ac8330a57cc0810d29006d