### PR TITLE
Avoid restarting media when joining active regions

### DIFF
--- a/client/src/client/services/socket/handlers/HandleCreateMedia.jsx
+++ b/client/src/client/services/socket/handlers/HandleCreateMedia.jsx
@@ -13,6 +13,14 @@ export async function handleCreateMedia(data) {
     return Math.round(((maxDistance - currentDistance) / maxDistance) * 100);
   }
 
+  function normalizeInstant(value) {
+    if (!value) return null;
+    if (value instanceof Date) return value.getTime();
+    if (typeof value === 'number') return value;
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
   const looping = data.media.loop;
   const { startInstant } = data.media;
   const id = data.media.mediaId;
@@ -28,82 +36,134 @@ export async function handleCreateMedia(data) {
   let volume = 100;
 
   await MEDIA_MUTEX.lock();
-  const initialSource = source;
-  source = await sourceRewriter.translate(source);
-  console.log(`translaged source ${initialSource} to ${source}`);
-  let preloaded;
   try {
-    preloaded = await AudioPreloader.getResource(source, false, true);
-  } catch (e) {
-    console.error(`Failed to load audio from ${source}`, e);
-    MEDIA_MUTEX.unlock();
-    return;
-  }
+    const initialSource = source;
+    source = await sourceRewriter.translate(source);
+    console.log(`translaged source ${initialSource} to ${source}`);
 
-  // only if its a new version and provided, then use that volume
-  if (data.media.volume != null) {
-    volume = data.media.volume;
-  }
+    // Engine path: create or reuse channel
+    const engine = MediaManager.engine instanceof MediaEngine ? MediaManager.engine : new MediaEngine();
+    const existingChannel = engine.channels.get(id);
+    const normalizedStartAt = startAtMillis ?? 0;
+    const normalizedSpeed = (speed != null && speed !== 0) ? speed : 100;
 
-  // attempt to stop the existing one, if any
-  MediaManager.destroySounds(id, false, true);
+    if (existingChannel && existingChannel.tracks && existingChannel.tracks.size > 0) {
+      const iterator = existingChannel.tracks.values().next();
+      const existingTrack = iterator && !iterator.done ? iterator.value : null;
+      const existingInstant = normalizeInstant(existingTrack ? existingTrack.startInstant : null);
+      const targetInstant = normalizeInstant(startInstant);
+      const instantsMatch = (existingInstant == null && targetInstant == null)
+        || (existingInstant != null && targetInstant != null && Math.abs(existingInstant - targetInstant) <= 250);
+      const canReuse = existingTrack
+        && existingTrack.source === source
+        && existingTrack.loop === !!looping
+        && (existingTrack.startAtMillis ?? 0) === normalizedStartAt
+        && (existingTrack.speedPct ?? 100) === normalizedSpeed
+        && instantsMatch
+        && existingTrack.state !== 'destroyed'
+        && existingTrack.state !== 'stopped';
 
-  // Engine path: create or reuse channel
-  const engine = MediaManager.engine instanceof MediaEngine ? MediaManager.engine : new MediaEngine();
-  const newChannel = engine.ensureChannel(id, volume);
-  newChannel.setTag(id);
+      if (canReuse) {
+        try {
+          existingTrack.setLoop(looping);
+          if (existingTrack.speedPct !== normalizedSpeed) existingTrack.setPlaybackSpeed(normalizedSpeed);
+          // Re-apply server synced position in case our local timer drifted while paused/loading.
+          if (doPickup) existingTrack.applyStartDateIfAny();
+          existingChannel.setTag(id);
+          existingChannel.setTag(flag);
+          if (maxDistance !== 0) {
+            existingChannel.setTag('SPECIAL');
+            existingChannel.maxDistance = maxDistance;
+            const startVolume = convertDistanceToVolume(maxDistance, distance);
+            existingChannel.fadeTo(startVolume, fadeTime);
+          } else {
+            existingChannel.setTag('DEFAULT');
+            if (fadeTime === 0) {
+              existingChannel.setChannelVolumePct(volume);
+            } else {
+              existingChannel.fadeTo(volume, fadeTime);
+            }
+          }
+          await existingTrack.play();
+        } catch (reuseErr) {
+          console.warn(`Failed to reuse media channel ${id}, falling back to full reload`, reuseErr);
+        }
+        return;
+      }
+    }
 
-  // Use the same fadeTime as the media to crossfade regions/speakers
-  if (muteRegions) { debugLog('Incrementing region inhibit'); MediaManager.engine.incrementInhibitor('REGION', fadeTime); }
-  if (muteSpeakers) { debugLog('Incrementing speaker inhibit'); MediaManager.engine.incrementInhibitor('SPEAKER', fadeTime); }
-
-  // Undo inhibitors when the engine channel is finally removed
-  engine.whenFinished(id, async () => {
-    // eslint-disable-next-line no-console
-    console.log(`Channel ${id} finished, removing inhibitors`);
+    let preloaded;
     try {
-      await MEDIA_MUTEX.unlock();
-      if (muteRegions) MediaManager.engine.decrementInhibitor('REGION', fadeTime);
-      if (muteSpeakers) MediaManager.engine.decrementInhibitor('SPEAKER', fadeTime);
-    } finally {
-      MEDIA_MUTEX.unlock();
+      preloaded = await AudioPreloader.getResource(source, false, true);
+    } catch (e) {
+      console.error(`Failed to load audio from ${source}`, e);
+      return;
     }
-  });
 
-  newChannel.setTag(flag);
-  // Preload audio element and create track
-  const track = new MediaTrack({
-    id: `${id}::0`, source, audio: preloaded, loop: looping, startAtMillis, startInstant,
-  });
+    // only if its a new version and provided, then use that volume
+    if (data.media.volume != null) {
+      volume = data.media.volume;
+    }
 
-  if (speed != null && speed !== 1 && speed !== 0) track.setPlaybackSpeed(speed);
-  newChannel.addTrack(track);
-  if (!looping) {
-    track.onEnded(() => {
-      if (MediaManager.engine) MediaManager.engine.removeChannel(id);
+    // attempt to stop the existing one, if any
+    MediaManager.destroySounds(id, false, true);
+
+    const newChannel = engine.ensureChannel(id, volume);
+    newChannel.setTag(id);
+
+    // Use the same fadeTime as the media to crossfade regions/speakers
+    if (muteRegions) { debugLog('Incrementing region inhibit'); MediaManager.engine.incrementInhibitor('REGION', fadeTime); }
+    if (muteSpeakers) { debugLog('Incrementing speaker inhibit'); MediaManager.engine.incrementInhibitor('SPEAKER', fadeTime); }
+
+    // Undo inhibitors when the engine channel is finally removed
+    engine.whenFinished(id, async () => {
+      // eslint-disable-next-line no-console
+      console.log(`Channel ${id} finished, removing inhibitors`);
+      try {
+        await MEDIA_MUTEX.unlock();
+        if (muteRegions) MediaManager.engine.decrementInhibitor('REGION', fadeTime);
+        if (muteSpeakers) MediaManager.engine.decrementInhibitor('SPEAKER', fadeTime);
+      } finally {
+        MEDIA_MUTEX.unlock();
+      }
     });
-  }
 
-  newChannel.setChannelVolumePct(0);
-  // convert distance
-  if (maxDistance !== 0) {
-    const startVolume = convertDistanceToVolume(maxDistance, distance);
-    newChannel.setTag('SPECIAL');
-    newChannel.maxDistance = maxDistance;
-    newChannel.fadeTo(startVolume, fadeTime);
-  } else {
-    // default sound, just play
-    newChannel.setTag('DEFAULT');
+    newChannel.setTag(flag);
+    // Preload audio element and create track
+    const track = new MediaTrack({
+      id: `${id}::0`, source, audio: preloaded, loop: looping, startAtMillis, startInstant,
+    });
 
-    if (fadeTime === 0) {
-      newChannel.setChannelVolumePct(volume);
-    } else {
-      newChannel.fadeTo(volume, fadeTime);
+    if (speed != null && speed !== 1 && speed !== 0) track.setPlaybackSpeed(speed);
+    newChannel.addTrack(track);
+    if (!looping) {
+      track.onEnded(() => {
+        if (MediaManager.engine) MediaManager.engine.removeChannel(id);
+      });
     }
-  }
 
-  MEDIA_MUTEX.unlock();
-  // Start playback via MediaTrack
-  if (doPickup) { /* startInstant already handled by track */ }
-  await track.play();
+    newChannel.setChannelVolumePct(0);
+    // convert distance
+    if (maxDistance !== 0) {
+      const startVolume = convertDistanceToVolume(maxDistance, distance);
+      newChannel.setTag('SPECIAL');
+      newChannel.maxDistance = maxDistance;
+      newChannel.fadeTo(startVolume, fadeTime);
+    } else {
+      // default sound, just play
+      newChannel.setTag('DEFAULT');
+
+      if (fadeTime === 0) {
+        newChannel.setChannelVolumePct(volume);
+      } else {
+        newChannel.fadeTo(volume, fadeTime);
+      }
+    }
+
+    // Start playback via MediaTrack
+    if (doPickup) { /* startInstant already handled by track */ }
+    await track.play();
+  } finally {
+    MEDIA_MUTEX.unlock();
+  }
 }


### PR DESCRIPTION
## Summary
- detect when a ClientCreateMedia payload describes the same track that is already playing
- reuse the existing media channel and refresh its volume/position instead of destroying and recreating it
- ensure media playback continues smoothly for region joins and refreshes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf83a8857c8330864f6f8de0a3f53b