### PR TITLE
Expose plugin WebSocket endpoint and refresh docs

### DIFF
--- a/client/server/curl-play.md
+++ b/client/server/curl-play.md
@@ -47,3 +47,26 @@ curl -X POST http://localhost:8080/admin/video/pause \
   -d '{"token":"565", "atMs": 12000}'
 ```
 
+---
+
+## Minecraft Plugin WebSocket (Development)
+
+If you are working on the Minecraft plugin you can connect it directly to the backend without issuing cURL requests:
+
+* **Endpoint:** `ws://localhost:8080/ws/plugin?token=YOUR_PLUGIN_TOKEN`
+* **Token:** supply the same value you configured for `PLUGIN_TOKEN` in `.env` (default `changeme`).
+
+Send JSON payloads with the same `type` names and fields as the HTTP helpers. Example:
+
+```json
+{
+  "id": "region-sync",
+  "type": "SET_REGION",
+  "playerUuid": "a7b49cc2-2bdb-4e4e-aa45-95daadcc2369",
+  "regionId": "spawn"
+}
+```
+
+The server answers each command with a `PLUGIN_RESPONSE` message that includes the HTTP status and body you would normally get
+back from the REST API.
+

--- a/client/server/curl-production.md
+++ b/client/server/curl-production.md
@@ -84,3 +84,17 @@ curl -X POST https://audio.boykevanvugt.nl/api/admin/video/play \
   -H "x-admin-key: changeme" \
   -d '{"playerId":"PLAYER_ID_HERE"}'
 ```
+
+---
+
+## Minecraft Plugin WebSocket (Production)
+
+For production servers the plugin connects to the API host via WebSocket:
+
+* **Endpoint:** `wss://audio.boykevanvugt.nl/api/ws/plugin?token=YOUR_PLUGIN_TOKEN`
+* **Token:** use the `PLUGIN_TOKEN` configured on the server (matches the `.env` value). Connections with an incorrect token are
+  closed immediately.
+
+Once connected you can send the same JSON payloads as the REST helpers (`SET_REGION`, `VIDEO_INIT`, `VIDEO_PLAY`, `VIDEO_PAUSE`,
+`VIDEO_SEEK`, `VIDEO_CLOSE`, `VIDEO_PLAY_INSTANT`, `VIDEO_PRELOAD`, `VIDEO_PLAYLIST_INIT`). The server responds with
+`PLUGIN_RESPONSE` messages mirroring the REST status/body.

--- a/client/server/curls.md
+++ b/client/server/curls.md
@@ -84,3 +84,34 @@ curl -X POST http://localhost:8080/admin/video/play \
   -H "x-admin-key: changeme" \
   -d '{"playerId":"PLAYER_ID_HERE"}'
 ```
+
+---
+
+## Minecraft Plugin WebSocket
+
+The backend also exposes a WebSocket endpoint for the Minecraft plugin so it can push the same JSON payloads without going
+through the admin REST API.
+
+* **Endpoint:** `ws://localhost:8080/ws/plugin?token=YOUR_PLUGIN_TOKEN`
+* **Token:** matches the `PLUGIN_TOKEN` value in your `.env` (defaults to `changeme`). Connections without the correct token are
+  rejected.
+
+When the socket opens the server sends a `PLUGIN_HELLO` payload that lists currently connected browser clients. Afterwards the
+plugin can send the same `type` values that the HTTP routes accept (`SET_REGION`, `VIDEO_INIT`, `VIDEO_PLAY`, `VIDEO_PAUSE`,
+`VIDEO_SEEK`, `VIDEO_CLOSE`, `VIDEO_PLAY_INSTANT`, `VIDEO_PRELOAD`, `VIDEO_PLAYLIST_INIT`). Include any targeting fields
+(`token`, `playerId`, `playerUuid`, `playerName`, or `regionId`) in the payload just like you would in the cURL requests.
+
+Example message:
+
+```json
+{
+  "id": "trigger-1",
+  "type": "VIDEO_PLAY_INSTANT",
+  "regionId": "spawn",
+  "url": "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+  "autoclose": true
+}
+```
+
+The server replies with `PLUGIN_RESPONSE` messages that echo the `id` (if provided) and include the HTTP status and body for
+the handled command.


### PR DESCRIPTION
## Summary
- refactor the admin video routes into shared helpers that both HTTP and WebSocket code paths reuse
- add a `/ws/plugin` WebSocket that authenticates with `PLUGIN_TOKEN` and forwards plugin messages to the existing handlers
- document the plugin WebSocket connection details alongside the development and production cURL guides

## Testing
- npm test -- --watch=false *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68cf9845f84483309bdc4c3f7d45e6bb