### PR TITLE
Ensure region playback state persists without listeners

### DIFF
--- a/client/server/index.js
+++ b/client/server/index.js
@@ -901,7 +901,9 @@ function handleVideoPlayInstantRequest(body = {}) {
 
   const { delivered: deliverInit } = deliverPayloadToTarget(target, initPayload, initContext, { displayName });
 
-  if (!deliverInit) {
+  const shouldSendPlay = deliverInit || target.kind === "region";
+
+  if (!shouldSendPlay) {
     const response = { delivered: false, stage: "init", target: target.kind };
     if (target.kind === "region") {
       response.regionId = target.value;
@@ -925,12 +927,16 @@ function handleVideoPlayInstantRequest(body = {}) {
 
   const response = {
     delivered: deliverInit && deliverPlay,
-    stage: deliverPlay ? "play" : "init",
+    stage: deliverPlay
+      ? "play"
+      : (deliverInit ? "init" : (target.kind === "region" ? "play" : "init")),
     target: target.kind,
   };
   if (target.kind === "region") {
     response.regionId = target.value;
     response.regionDisplayName = getRegionDisplayName(target.value);
+    response.initDelivered = deliverInit;
+    response.playDelivered = deliverPlay;
   }
 
   return { status: 200, body: response };


### PR DESCRIPTION
## Summary
- continue processing VIDEO_PLAY for regional targets even when no listeners are connected
- annotate region responses with delivery details so future joins can synchronize correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0b4afbf6083309147fb7e29839fe9