### PR TITLE
Support background customization for video modal

### DIFF
--- a/client/server/curl-play.md
+++ b/client/server/curl-play.md
@@ -17,6 +17,7 @@ curl -X POST http://localhost:8080/admin/video/init \
   -H "Content-Type: application/json" -H "x-admin-key: changeme" \
   -d '{"regionId":"spawn","url":"https://example.com/video.mp4","autoclose":true}'
 ```
+Add optional presentation keys like `backgroundImageUrl`, `backgroundImageTarget`, `backgroundImagePosition`, `backgroundImageRepeat`, `backgroundImageSize`, and `backdropBackgroundColor`/`modalBackgroundColor` to style the player shell.
 
 ## Play
 ```sh

--- a/client/server/curl-production.md
+++ b/client/server/curl-production.md
@@ -33,9 +33,13 @@ curl -X POST https://audio.wondercraftmc.nl/api/admin/video/init \
   -d '{
         "regionId": "spawn",
         "url": "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
-        "autoclose": true
+        "autoclose": true,
+        "backgroundImageUrl": "https://example.com/poster.jpg",
+        "backgroundImageTarget": "modal",
+        "backgroundImageSize": "cover"
       }'
 ```
+Optional extras: `backgroundImageTarget`, `backgroundImagePosition` (or `backgroundImagePositionX`/`backgroundImagePositionY`), `backgroundImageRepeat`, `backgroundImageAttachment`, `backgroundImageSize`, `backdropBackgroundColor`, `modalBackgroundColor`.
 
 ## POST /admin/video/play
 ```sh

--- a/client/server/curls.md
+++ b/client/server/curls.md
@@ -63,7 +63,8 @@ Prepare a video for a target or region.
 
 Body fields:
 - Required: `url`
-- Optional: `startAtEpochMs`, `muted` (bool), `volume` (0.0–1.0), `sessionId`, `autoclose` (bool)
+- Optional playback: `startAtEpochMs`, `muted` (bool), `volume` (0.0–1.0), `sessionId`, `autoclose` (bool)
+- Optional visuals: `backgroundImageUrl`, `backgroundImageTarget` (`"backdrop"` or `"modal"`), `backgroundImagePosition` (or `backgroundImagePositionX`/`backgroundImagePositionY`), `backgroundImageRepeat`, `backgroundImageSize`, `backgroundImageAttachment`, `backdropBackgroundColor`, `modalBackgroundColor`
 - Target: one of the targeting fields above
 
 Examples:
@@ -79,7 +80,11 @@ curl -X POST http://localhost:8080/admin/video/init \
         "muted": false,
         "volume": 1.0,
         "sessionId": "area-lobby",
-        "autoclose": false
+        "autoclose": false,
+        "backgroundImageUrl": "https://example.com/poster.jpg",
+        "backgroundImageTarget": "backdrop",
+        "backgroundImagePosition": "center center",
+        "backdropBackgroundColor": "rgba(0,0,0,0.65)"
       }'
 
 # Region broadcast

--- a/client/server/index.js
+++ b/client/server/index.js
@@ -65,6 +65,31 @@ function snapshotPayload(payload) {
   return payload ? JSON.parse(JSON.stringify(payload)) : payload;
 }
 
+function includeOptionalBackgroundFields(source, target) {
+  if (!source || typeof source !== "object" || !target || typeof target !== "object") return;
+  const optionalKeys = [
+    "backgroundImageUrl",
+    "backgroundImageTarget",
+    "backgroundImagePosition",
+    "backgroundImagePositionX",
+    "backgroundImagePositionY",
+    "backgroundImageRepeat",
+    "backgroundImageSize",
+    "backgroundImageAttachment",
+    "backdropBackgroundColor",
+    "modalBackgroundColor",
+    "backdropColor",
+    "modalColor",
+  ];
+
+  for (const key of optionalKeys) {
+    const value = source[key];
+    if (typeof value === "string" && value.length > 0) {
+      target[key] = value;
+    }
+  }
+}
+
 function ensureMediaRecord(store, key) {
   let record = store.get(key);
   if (!record) {
@@ -790,6 +815,7 @@ function handleVideoInitRequest(body = {}) {
     volume,
     autoclose: Boolean(body.autoclose),
   };
+  includeOptionalBackgroundFields(body, payload);
   const context = {};
   if (sessionId != null) context.sessionId = sessionId;
   const displayName = body.regionDisplayName || body.regionName || body.regionLabel || body.regionId;
@@ -894,6 +920,7 @@ function handleVideoPlayInstantRequest(body = {}) {
     volume,
     autoclose: Boolean(body.autoclose),
   };
+  includeOptionalBackgroundFields(body, initPayload);
 
   const initContext = {};
   if (sessionId != null) initContext.sessionId = sessionId;


### PR DESCRIPTION
## Summary
- expose CSS custom properties and runtime helpers so the video overlay can apply optional background imagery and colors from VIDEO_INIT payloads
- clear any backdrop/modal overrides when the player closes to restore defaults
- allow the control server and docs to pass along background image metadata untouched for clients

## Testing
- npm test (client/server)


------
https://chatgpt.com/codex/tasks/task_e_68d1f4f69d2c8330862046eb43574af7